### PR TITLE
fix: Improve clipboard detection for Ubuntu 24.04 Wayland

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -60,20 +60,30 @@
             (p: "run-shell ${p}/share/tmux-plugins/${p.pluginName}/${p.pluginName}.tmux")
             (builtins.attrValues pluginSet);
 
-          # clipboard command 
-          clipboardCmd = if pkgs.stdenv.isLinux
-            then (if pkgs.wayland != null
-              then "wl-copy"
-              else "xclip -section clipboard")
-            else "pbcopy";
+          # clipboard command - detect at runtime for proper system integration
+          clipboardScript = pkgs.writeShellScript "clipboard-copy" ''
+            if [ -n "$WAYLAND_DISPLAY" ] && command -v wl-copy >/dev/null 2>&1; then
+              wl-copy
+            elif [ -n "$DISPLAY" ] && command -v xclip >/dev/null 2>&1; then
+              xclip -selection clipboard
+            elif command -v wl-copy >/dev/null 2>&1; then
+              wl-copy  
+            elif command -v xclip >/dev/null 2>&1; then
+              xclip -selection clipboard
+            else
+              cat > /dev/null
+            fi
+          '';
 
           # tmux.conf as a var in nix
           tmuxConf = pkgs.replaceVars ./tmux.conf {
             pluginPath = allPlugins;
-            inherit pluginLoader clipboardCmd;
+            inherit pluginLoader;
+            clipboardCmd = clipboardScript;
           };
 
           tshmux = pkgs.writeShellScriptBin "tshmux" ''
+            export PATH=${pkgs.lib.makeBinPath [ pkgs.wl-clipboard pkgs.xclip ]}:$PATH
             exec ${pkgs.tmux}/bin/tmux -f ${tmuxConf} "$@"
           '';
         in {


### PR DESCRIPTION
The previous clipboard detection logic incorrectly checked if the wayland package exists in nixpkgs (which is always true), rather than detecting the actual runtime display server environment.

This commit:
- Implements runtime clipboard detection using WAYLAND_DISPLAY and DISPLAY environment variables
- Falls back to available clipboard tools (wl-copy, xclip) when display server detection fails
- Adds both wl-clipboard and xclip packages as runtime dependencies to ensure availability
- Creates a dedicated clipboard script that handles detection at runtime rather than build time

Fixes copy-paste functionality on Ubuntu 24.04 where copy mode worked (Alt+q, Shift+v, y) but paste would not insert any content.