### PR TITLE
feat: add session delete keybinding (Alt+Shift+X)

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,8 @@ tshmux comes with a curated set of tmux plugins, automatically managed through N
 ### Session Management
 | Key | Action | Description |
 |-----|--------|-------------|
-| `Alt+s` | Session switcher | Open session tree chooser |
+| `Alt+s` | Session switcher | Open session tree chooser (press `x` inside to kill a session) |
+| `Alt+Shift+X` | Kill session | Delete the current session (with confirmation prompt) |
 
 ### Copy Mode & Clipboard
 | Key | Action | Description |

--- a/tmux.conf
+++ b/tmux.conf
@@ -15,6 +15,9 @@ bind -n M-q copy-mode
 # Bind Alt-s to session switcher
 bind -n M-s choose-tree -s
 
+# Bind Alt-Shift-X to kill/delete the current session (with confirmation)
+bind -n M-X confirm-before -p "Kill session '#S'? (y/n)" kill-session
+
 # Bind Alt-h/j/k/l to go to specific windows
 bind -n M-h select-window -t 0
 bind -n M-j select-window -t 1


### PR DESCRIPTION
Adds M-X (Alt+Shift+X) binding to remove the current tmux session with a confirmation prompt. Also documents that Alt+s (choose-tree) supports pressing 'x' to delete individual sessions from the tree view.