### PR TITLE
fix: enable mouse support so scroll wheel scrolls terminal buffer

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -51,6 +51,15 @@ set -g status-keys vi
 
 set -sg escape-time 0
 
+# Enable mouse support so the scroll wheel scrolls the terminal buffer
+# instead of navigating command history
+set -g mouse on
+
+# On scroll, enter copy-mode and scroll up; on scroll-down exit copy-mode at bottom
+bind -n WheelUpPane if-shell -F "#{?pane_in_mode,1,#{?alternate_on,1,0}}" \
+  "send-keys -M" \
+  "copy-mode -e; send-keys -M"
+
 # Enter copy-mode with Alt-q
 unbind -n M-q
 bind -n M-q copy-mode


### PR DESCRIPTION
Add `set -g mouse on` so the mouse wheel enters copy-mode and scrolls the terminal output buffer instead of sending up/down key events to the shell (which navigated command history).

Also add a WheelUpPane binding that transparently passes scroll events through when already in copy-mode or an alternate-screen application (e.g. vim, less), and enters copy-mode for plain panes.