### PR TITLE
fix(shell): start panes as interactive login shells for NVM compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,27 @@ tshmux/
 * **tmux** (automatically provided by Nix)
 * **System clipboard tools** (automatically detected: wl-copy, xclip, or pbcopy)
 
-The configuration automatically sets zsh as the default shell through Nix paths.
+The configuration respects your system's configured shell via `$SHELL`, launching each pane as an interactive login shell.
+
+---
+
+## NVM and Shell Version Manager Compatibility
+
+tshmux starts each tmux pane as an **interactive login shell** (`$SHELL -l`). This ensures both your login profile (`~/.zprofile` or `~/.bash_profile`) and your interactive RC file (`~/.zshrc` or `~/.bashrc`) are sourced, so tools like NVM, rbenv, pyenv, and similar version managers initialize correctly.
+
+### Why this matters
+
+NVM and similar tools initialize themselves by adding a shell function (e.g., `nvm`) to the shell session. These functions are typically defined in `~/.zshrc` or `~/.bashrc`. A pure login shell sources `.zprofile`/`.bash_profile` but not `.zshrc` on many systems, so the `nvm` function is never defined.
+
+### If NVM is still not found
+
+1. **Verify NVM init is in your RC file**: Confirm that `~/.zshrc` (or `~/.bashrc`) contains:
+   ```sh
+   export NVM_DIR="$HOME/.nvm"
+   [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+   ```
+2. **Or move NVM init to your login profile**: Place the above lines in `~/.zprofile` (zsh) or `~/.bash_profile` (bash) instead.
+3. **Restart your tshmux session** after any profile changes — existing panes will not pick up changes until a new shell is started.
 
 ---
 

--- a/flake.nix
+++ b/flake.nix
@@ -82,10 +82,18 @@
             clipboardCmd = clipboardScript;
           };
 
-          tshmux = pkgs.writeShellScriptBin "tshmux" ''
+          tshmuxScript = pkgs.writeShellScriptBin "tshmux" ''
             export PATH=${pkgs.lib.makeBinPath [ pkgs.wl-clipboard pkgs.xclip ]}:$PATH
             exec ${pkgs.tmux}/bin/tmux -f ${tmuxConf} "$@"
           '';
+
+          tshmux = pkgs.symlinkJoin {
+            name = "tshmux";
+            paths = [ tshmuxScript ];
+            postBuild = ''
+              ln -s $out/bin/tshmux $out/bin/tmux
+            '';
+          };
         in {
           default = tshmux;
           inherit tshmux allPlugins;

--- a/tmux.conf
+++ b/tmux.conf
@@ -51,6 +51,10 @@ set -g status-keys vi
 
 set -sg escape-time 0
 
+# NVM and shell tool compatibility: start panes as interactive login shells
+# so both .zprofile/.bash_profile and .zshrc/.bashrc are sourced.
+set -g default-command "${SHELL} -l"
+
 # Enable mouse support so the scroll wheel scrolls the terminal buffer
 # instead of navigating command history
 set -g mouse on


### PR DESCRIPTION
## Summary

- Adds `set -g default-command "${SHELL} -l"` to `tmux.conf` — every new pane now starts as an interactive login shell, so both `.zprofile`/`.bash_profile` and `.zshrc`/`.bashrc` are sourced. This makes `nvm` (and other version managers) initialize correctly in all panes.
- Refactors `flake.nix`: separates `tshmuxScript` into a named binding, then wraps it with `symlinkJoin` to create a `tmux` symlink alongside `tshmux` — the fix applies regardless of which command the user invokes.
- Updates `README.md`: fixes the inaccurate "sets zsh as default shell" line and adds a new **NVM and Shell Version Manager Compatibility** section with troubleshooting steps.

Fixes #7.

## Test plan

- [ ] `nix build` completes without errors on x86_64-linux
- [ ] New tshmux panes have `nvm --version` available when NVM is initialized in `~/.zshrc`
- [ ] Panes from splits (`Alt+-`, `Alt+_`) also get NVM-initialized shells
- [ ] Both `tshmux` and `tmux` (via symlink) exhibit the same shell behaviour